### PR TITLE
Add convenience options

### DIFF
--- a/show.py
+++ b/show.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import argparse
 
-from stepback.record import Record, SCORE_NAMES
+from stepback.record import Record
 from stepback.utils import get_output_filenames
 from stepback.plotting import plot_stability, plot_step_sizes
 

--- a/stepback/plotting.py
+++ b/stepback/plotting.py
@@ -12,7 +12,18 @@ from .record import SCORE_NAMES, id_to_dict, create_label
 ###################################
 
 
-def plot_stability(R, score='val_score', xaxis='lr', sigma=1, cutoff=None, legend=None, ylim=None, log_scale=True, figsize=(6,5), save=False):
+def plot_stability(R, 
+                   score='val_score', 
+                   xaxis='lr', 
+                   sigma=1, 
+                   cutoff=None,
+                   ignore_columns=list(), 
+                   legend=None, 
+                   ylim=None, 
+                   log_scale=True, 
+                   figsize=(6,5), 
+                   save=False
+                   ):
     """
     Generates stability plot.
 
@@ -21,6 +32,7 @@ def plot_stability(R, score='val_score', xaxis='lr', sigma=1, cutoff=None, legen
         xaxis: parameter to group by, for example 'lr' for initial learning rate
         sigma: number of standard deviations to show (in one direction)
         cutoff: if not None, score is aggregated over [cutoff, max_epoch]
+        ignore_columns: columns from id_df that are ignored for grouping. For example, useful when xaxis=lr but weight_decay is also different for each lr.
         legend: 'full', None, or a list of keys that are displayed, e.g. ['lr', 'weight_decay']
         ylim: Set ylim values. By default will be set to [0,1] for <_score> metrics
         log_scale: Use log-scale for <_loss> metrics. Not used for <_score> metrics
@@ -47,8 +59,10 @@ def plot_stability(R, score='val_score', xaxis='lr', sigma=1, cutoff=None, legen
     for j, s in enumerate(score):
         # filter epochs
         sub_df = base_df[(base_df.epoch >= cutoff_epoch[0]) & (base_df.epoch <= cutoff_epoch[1])] 
+        # select the columns to group by
+        grouping_cols = [c for c in id_df.columns if c not in ignore_columns]
         # group by all id_cols 
-        df = sub_df.groupby(list(id_df.columns))[[s, s+'_std']].mean() # use dropna=False if we would have nan values
+        df = sub_df.groupby(grouping_cols)[[s, s+'_std']].mean() # use dropna=False if we would have nan values
         # move xaxis out of grouping
         df = df.reset_index(level=xaxis)
         # make xaxis float

--- a/stepback/utils.py
+++ b/stepback/utils.py
@@ -115,6 +115,13 @@ def merge_output_files(exp_id_list, fname, output_dir='output/', merged_dir=None
     for _e in exp_id_list:
         C = Container(name=_e, output_dir=output_dir, as_json=as_json)
         C.load() # load data
+        
+        # if stored as single dict ouput, make list of length one
+        if isinstance(C.data, dict):
+            for key in ["config", "summary", "history"]:
+                assert key in C.data.keys()
+            C.data = [C.data]
+
         merged.data += C.data # append
 
     all_model = set([d['config']['model'] for d in merged.data])


### PR DESCRIPTION
* allows to ignore a column for stability plots (e.g. when weight decay is different for lr)
* allows merging for output files that are a single dictionary (and not a list with one dictionary element)